### PR TITLE
BCD-esque fiction data for api.Hightlight.type

### DIFF
--- a/example-data/api/Highlight.json
+++ b/example-data/api/Highlight.json
@@ -1,0 +1,60 @@
+{
+  "api": {
+    "Highlight": {
+      "type": {
+        "__compat": {
+          "description": "Semantic highlight type exposed to users",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Highlight/type",
+          "spec_url": "https://drafts.csswg.org/css-highlight-api-1/#highlight-types",
+          "tags": [
+            "web-features:highlight"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "105",
+              "nvda": {
+                "version_added": false,
+                "devices": ["Linux", "Windows", "macOS"]
+              },
+              "jaws": {
+                "version_added": false,
+                "devices": ["Linux", "Windows", "macOS"]
+              }
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "140",
+              "nvda": {
+                "version_added": "1.4",
+                "devices": ["Linux", "Windows", "macOS"]
+              },
+              "voiceover": {
+                "version_added": "26",
+                "devices": ["macOS"],
+                "partial_implementation": true,
+                "notes": "Truncates the line and only starts reading from the highlight."
+              }
+            },
+            "safari": {
+              "version_added": "17.2",
+              "nvda": {
+                "version_added": false,
+                "devices": ["Linux", "Windows", "macOS"]
+              },
+              "jaws": {
+                "version_added": false,
+                "devices": ["Linux", "Windows", "macOS"]
+              },
+              "voiceover": {
+                "version_added": "26",
+                "devices": ["macOS"],
+                "partial_implementation": true,
+                "notes": "Truncates the line and only starts reading from the highlight."
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/example-data/api/Highlight.json
+++ b/example-data/api/Highlight.json
@@ -10,47 +10,57 @@
             "web-features:highlight"
           ],
           "support": {
-            "chrome": {
-              "version_added": "105",
-              "nvda": {
-                "version_added": false,
+            "chrome/nvda": [
+              {
+                "version_added": "105/8.8",
                 "devices": ["Linux", "Windows", "macOS"]
               },
-              "jaws": {
-                "version_added": false,
+              {
+                "version_added": "105/6.6",
+                "devices": ["Linux", "Windows"]
+              },
+              {
+                "version_added": "105/false",
                 "devices": ["Linux", "Windows", "macOS"]
               }
+            ],
+            "chrome/jaws": {
+              "version_added": "105/false",
+              "devices": ["Linux", "Windows", "macOS"]
             },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": "140",
-              "nvda": {
-                "version_added": "1.4",
-                "devices": ["Linux", "Windows", "macOS"]
-              },
-              "voiceover": {
-                "version_added": "26",
-                "devices": ["macOS"],
-                "partial_implementation": true,
-                "notes": "Truncates the line and only starts reading from the highlight."
-              }
+            "firefox/nvda": {
+              "version_added": "140/1.4",
+              "devices": ["Linux", "Windows", "macOS"]
             },
-            "safari": {
-              "version_added": "17.2",
-              "nvda": {
-                "version_added": false,
-                "devices": ["Linux", "Windows", "macOS"]
-              },
-              "jaws": {
-                "version_added": false,
-                "devices": ["Linux", "Windows", "macOS"]
-              },
-              "voiceover": {
-                "version_added": "26",
-                "devices": ["macOS"],
-                "partial_implementation": true,
-                "notes": "Truncates the line and only starts reading from the highlight."
-              }
+            "firefox/voiceover": {
+              "version_added": "140/26",
+              "devices": ["macOS"],
+              "failures": [
+                {
+                  "category": "bad-context",
+                  "description": "Truncates the line and only starts reading from the highlight",
+                  "bug": "https://…"
+                }
+              ]
+            },
+            "safari/nvda": {
+              "version_added": "17.2/false",
+              "devices": ["Linux", "Windows", "macOS"]
+            },
+            "safari/jaws": {
+              "version_added": "17.6/false",
+              "devices": ["Linux", "Windows", "macOS"]
+            },
+            "safari/voiceover": {
+              "version_added": "17.6/26",
+              "devices": ["macOS"],
+              "failures": [
+                {
+                  "category": "bad-context",
+                  "description": "Truncates the line and only starts reading from the highlight",
+                  "bug": "https://…"
+                }
+              ]
             }
           }
         }

--- a/example-data/api/Highlight.json
+++ b/example-data/api/Highlight.json
@@ -10,31 +10,33 @@
             "web-features:highlight"
           ],
           "support": {
-            "chrome/nvda": [
-              {
-                "version_added": "105/8.8",
-                "devices": ["Linux", "Windows", "macOS"]
-              },
-              {
-                "version_added": "105/6.6",
-                "devices": ["Linux", "Windows"]
-              },
-              {
-                "version_added": "105/false",
-                "devices": ["Linux", "Windows", "macOS"]
-              }
-            ],
+            "chrome/nvda": {
+                "version_added": false
+            },
             "chrome/jaws": {
-              "version_added": "105/false",
-              "devices": ["Linux", "Windows", "macOS"]
+              "version_added": false
+            },
+            "chrome_android/talkback": {
+              "version_added": false
             },
             "firefox/nvda": {
-              "version_added": "140/1.4",
-              "devices": ["Linux", "Windows", "macOS"]
+              "version_added": false
             },
-            "firefox/voiceover": {
+            "firefox/jaws": {
+              "version_added": "140/2025"
+            },
+            "firefox/voiceover_macos": {
               "version_added": "140/26",
-              "devices": ["macOS"],
+              "failures": [
+                {
+                  "category": "bad-context",
+                  "description": "Truncates the line and only starts reading from the highlight",
+                  "bug": "https://…"
+                }
+              ]
+            },
+            "firefox/voiceover_ios": {
+              "version_added": "140/26",
               "failures": [
                 {
                   "category": "bad-context",
@@ -44,16 +46,23 @@
               ]
             },
             "safari/nvda": {
-              "version_added": "17.2/false",
-              "devices": ["Linux", "Windows", "macOS"]
+              "version_added": false
             },
             "safari/jaws": {
-              "version_added": "17.6/false",
-              "devices": ["Linux", "Windows", "macOS"]
+              "version_added": false
             },
-            "safari/voiceover": {
+            "safari/voiceover_macos": {
               "version_added": "17.6/26",
-              "devices": ["macOS"],
+              "failures": [
+                {
+                  "category": "bad-context",
+                  "description": "Truncates the line and only starts reading from the highlight",
+                  "bug": "https://…"
+                }
+              ]
+            },
+            "safari_ios/voiceover_ios": {
+              "version_added": "17.6/26",
               "failures": [
                 {
                   "category": "bad-context",

--- a/example-data/html/elements/a.json
+++ b/example-data/html/elements/a.json
@@ -1,0 +1,53 @@
+{
+  "html": {
+    "elements": {
+      "a": {
+        "a_without_href": {
+          "__compat": {
+            "description": "`<a>` (without `href` attribute)",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Elements/a",
+            "spec_url": "https://w3c.github.io/html-aam/#el-a-no-href",
+            "tags": [
+              "web-features:a"
+            ],
+            "support": {
+              "chrome/nvda": {
+                "version_added": "1/1.4"
+              },
+              "chrome/jaws": {
+                "version_added": "1/2.4"
+              },
+              "chrome_android/talkback": {
+                "version_added": "1/1"
+              },
+              "firefox/nvda": {
+                "version_added": "1/1.4"
+              },
+              "firefox/jaws": {
+                "version_added": "1/2.4"
+              },
+              "firefox/voiceover_macos": {
+                "version_added": "1/1"
+              },
+              "firefox/voiceover_ios": {
+                "version_added": "1/1"
+              },
+              "safari/nvda": {
+                "version_added": "1/1.4"
+              },
+              "safari/jaws": {
+                "version_added": "1/2.4"
+              },
+              "safari/voiceover_macos": {
+                "version_added": "1/1"
+              },
+              "safari_ios/voiceover_ios": {
+                "version_added": "1/1"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This data is fiction. 

I was wondering if we could come to a BCD-like data format for ACD. Based on a discussion shared with me from mastodon: https://mas.to/@patrickbrosset/114782908880409941

Basically, the idea here is that such a structure could complement the information we have in BCD (`api.Highlight.type`) and therefore offer a direct hook to any BCD consumers (such as web-features or "baseline").

