### PR TITLE
MDN Short Survey Questions

### DIFF
--- a/mdn-short-survey.md
+++ b/mdn-short-survey.md
@@ -1,0 +1,57 @@
+[Examples of past MDN Short Surveys](https://github.com/web-platform-dx/developer-research/tree/main/mdn-short-surveys)
+
+## Questions
+
+1. When checking your website/application for accessibility conformance,
+   rate how easy or challenging are the following aspects:
+   (options listed in random order, each option listed with 5 choices:
+   "very easy", "easy", "neutral", "somewhat challenging", "very challenging")
+  - Testing with assistive technologies (e.g., screen readers, voice control)
+  - Ensuring accessibility across different browsers and devices
+  - Testing keyboard navigation and focus management
+  - Checking semantic markup and ARIA implementation
+
+2. Do you use accessibility interoperability data
+   (information about how accessibility features work
+   across different browsers, assistive technologies,
+   or devices) in your development process?
+  - Yes, regularly
+  - Yes, occasionally
+  - Rarely
+  - No, but I'm interested in using it
+  - No, and I'm not sure what this refers to
+  - No, I don't see the need for it
+
+3. If you use accessibility interoperability data,
+   from which sources do you typically gather this
+   information? (select all that apply;
+   skip if you answered "No" to the previous question)
+  - Browser compatibility tables (e.g. Can I Use)
+  - Online documentation (e.g. MDN, WebAIM)
+  - Assistive technology testing results databases (e.g. a11ysupport.io)
+  - Community forums and discussions (e.g. Stack Overflow, accessibility communities)
+  - Official browser or assistive technology documentation
+  - Internal company testing and documentation
+  - Open source accessibility testing tools and their outputs
+  - Other (please specify): ___________
+
+4. How do you typically use accessibility interoperability
+   data in your workflow? (select all that apply;
+   skip if you don't use such data)
+  - To decide which accessibility techniques to implement
+  - To prioritise which browsers/assistive technologies to test with
+  - To debug accessibility issues that don't work consistently
+  - To set expectations with stakeholders about accessibility support
+  - To choose between different accessible implementation approaches
+  - To validate that my accessibility solutions will work for users
+  - To stay updated on accessibility best practices
+  - Other (please specify): ___________
+
+5. What are the main challenges you face when trying
+   to ensure your web content is accessible across
+    different browsers and assistive technologies?
+    (free form text entry)
+
+6. What additional accessibility interoperability 
+  information or tools would be most helpful 
+  for your development workflow? (free form text entry)


### PR DESCRIPTION
This addresses #7.

These questions are to be run on MDN pending review from the WebDX community group. The questions are focused on how developers use accessibility interoperability data for conformance testing and the potential issues they may run into. The longest MDN short survey has 5 questions, but they tend to have 2-3 questions, so it's very possible that we'll either split this survey up or only ask a subset of the proposed questions. You can view [examples here](https://github.com/web-platform-dx/developer-research/tree/main/mdn-short-surveys).