### PR TITLE
More BCDesque test data for text semantics (mark, ins, s, del)

### DIFF
--- a/example-data/html/elements/del.json
+++ b/example-data/html/elements/del.json
@@ -1,0 +1,32 @@
+{
+  "html": {
+    "elements": {
+      "del": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Elements/del",
+          "spec_url": "https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-del-element",
+          "tags": [
+            "web-features:del"
+          ],
+          "support": {
+            "safari/voiceover_macos": [
+              {
+                "version_added": "18/1",
+                "failures": [
+                   {
+                    "category": "bad-context",
+                    "description": "As of Safari 18, VoiceOver does not announce text preceding `<del>` when using read-all.",
+                    "bug": "https://bugs.webkit.org/show_bug.cgi?id=286267"
+                  }
+                ]
+              },
+              {
+                 "version_added": "5.1/1"
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/example-data/html/elements/ins.json
+++ b/example-data/html/elements/ins.json
@@ -1,0 +1,32 @@
+{
+  "html": {
+    "elements": {
+      "ins": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Elements/ins",
+          "spec_url": "https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-ins-element",
+          "tags": [
+            "web-features:ins"
+          ],
+          "support": {
+            "safari/voiceover_macos": [
+              {
+                "version_added": "18/1",
+                "failures": [
+                   {
+                    "category": "bad-context",
+                    "description": "As of Safari 18, VoiceOver does not announce text preceding `<ins>` when using read-all.",
+                    "bug": "https://bugs.webkit.org/show_bug.cgi?id=286267"
+                  }
+                ]
+              },
+              {
+                 "version_added": "5.1/1"
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/example-data/html/elements/mark.json
+++ b/example-data/html/elements/mark.json
@@ -1,0 +1,32 @@
+{
+  "html": {
+    "elements": {
+      "mark": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Elements/mark",
+          "spec_url": "https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-mark-element",
+          "tags": [
+            "web-features:mark"
+          ],
+          "support": {
+            "safari/voiceover_macos": [
+              {
+                "version_added": "18/1",
+                "failures": [
+                   {
+                    "category": "bad-context",
+                    "description": "As of Safari 18, VoiceOver does not announce text preceding `<mark>` when using read-all.",
+                    "bug": "https://bugs.webkit.org/show_bug.cgi?id=286267"
+                  }
+                ]
+              },
+              {
+                 "version_added": "5.1/1"
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/example-data/html/elements/s.json
+++ b/example-data/html/elements/s.json
@@ -1,0 +1,32 @@
+{
+  "html": {
+    "elements": {
+      "s": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Elements/s",
+          "spec_url": "https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-s-element",
+          "tags": [
+            "web-features:s"
+          ],
+          "support": {
+            "safari/voiceover_macos": [
+              {
+                "version_added": "18/1",
+                "failures": [
+                   {
+                    "category": "bad-context",
+                    "description": "As of Safari 18, VoiceOver does not announce text preceding `<s>` when using read-all.",
+                    "bug": "https://bugs.webkit.org/show_bug.cgi?id=286267"
+                  }
+                ]
+              },
+              {
+                 "version_added": "5.1/1"
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Again, untested fiction data (half truth, I guess, given the PRs that were filed with BCD recently contained this information, so somewhat realistic).

The idea here would be:

- The keys sit under acd.html.elements.del, acd.html.elements.ins, etc. sharing the same namespace as bcd.html.elements.del and therefore complementing the BCD information.
- The keys are tagged with the web-feature they belong to (allowing future baseline calc if one wants to)
- "safari/voiceover_macos" is the browser/AT combination where we have data
- "18/1" are the version numbers for said browser/AT software.
- I used an array support statement to basically say: All is fine between Safari 5.1 and Safari 17.6 but from Safari 18 onwards, we have a failure which I categorized, described and linked to the bug.


Thoughts? Feedback?